### PR TITLE
Minor refactor README for readability

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,5 @@
-Copyright (c) 2015 Adam Kliment
-
-MIT License
+The MIT License
+Copyright (c) 2015, 2016 Adam Kliment
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -66,3 +66,10 @@ rake
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
+
+## License
+
+See [`LICENSE`][license].
+
+  [license]: ./LICENSE.txt
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ruby Hooks Handler for Dredd API Testing Framework
 ==================================================
 
-[![Build Status](https://travis-ci.org/apiaryio/dredd-hooks-ruby.svg?branch=master)](https://travis-ci.org/apiaryio/dredd-hooks-ruby)
+[![Build Status](https://travis-ci.org/gonzalo-bulnes/dredd-hooks-ruby.svg?branch=master)](https://travis-ci.org/gonzalo-bulnes/dredd-hooks-ruby)
 [![Dependency Status](https://gemnasium.com/badges/github.com/gonzalo-bulnes/dredd-hooks-ruby.svg)](https://gemnasium.com/github.com/gonzalo-bulnes/dredd-hooks-ruby)
 
 Test your API with the [Dredd HTTP API testing framework](https://github.com/apiaryio/dredd) and write [hooks](http://dredd.readthedocs.org/en/latest/hooks/) in Ruby!

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Ruby Hooks Handler for Dredd API Testing Framework
 
 [![Build Status](https://travis-ci.org/gonzalo-bulnes/dredd-hooks-ruby.svg?branch=master)](https://travis-ci.org/gonzalo-bulnes/dredd-hooks-ruby)
 [![Dependency Status](https://gemnasium.com/badges/github.com/gonzalo-bulnes/dredd-hooks-ruby.svg)](https://gemnasium.com/github.com/gonzalo-bulnes/dredd-hooks-ruby)
+[![Inline Docs](http://inch-ci.org/github/gonzalo-bulnes/dredd-hooks-ruby.svg?branch=master)](http://inch-ci.org/github/gonzalo-bulnes/dredd-hooks-ruby)
 
 Test your API with the [Dredd HTTP API testing framework](https://github.com/apiaryio/dredd) and write [hooks](http://dredd.readthedocs.org/en/latest/hooks/) in Ruby!
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Ruby Hooks Handler for Dredd API Testing Framework
 ==================================================
 
 [![Build Status](https://travis-ci.org/apiaryio/dredd-hooks-ruby.svg?branch=master)](https://travis-ci.org/apiaryio/dredd-hooks-ruby)
+[![Dependency Status](https://gemnasium.com/badges/github.com/gonzalo-bulnes/dredd-hooks-ruby.svg)](https://gemnasium.com/github.com/gonzalo-bulnes/dredd-hooks-ruby)
 
 Test your API with the [Dredd HTTP API testing framework](https://github.com/apiaryio/dredd) and write [hooks](http://dredd.readthedocs.org/en/latest/hooks/) in Ruby!
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Ruby Hooks Handler for Dredd API Testing Framework
 
 [![Build Status](https://travis-ci.org/gonzalo-bulnes/dredd-hooks-ruby.svg?branch=master)](https://travis-ci.org/gonzalo-bulnes/dredd-hooks-ruby)
 [![Dependency Status](https://gemnasium.com/badges/github.com/gonzalo-bulnes/dredd-hooks-ruby.svg)](https://gemnasium.com/github.com/gonzalo-bulnes/dredd-hooks-ruby)
+[![Code Climate](https://codeclimate.com/github/gonzalo-bulnes/dredd-hooks-ruby/badges/gpa.svg)](https://codeclimate.com/github/gonzalo-bulnes/dredd-hooks-ruby)
 [![Inline Docs](http://inch-ci.org/github/gonzalo-bulnes/dredd-hooks-ruby.svg?branch=master)](http://inch-ci.org/github/gonzalo-bulnes/dredd-hooks-ruby)
 
 Test your API with the [Dredd HTTP API testing framework](https://github.com/apiaryio/dredd) and write [hooks](http://dredd.readthedocs.org/en/latest/hooks/) in Ruby!

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-
-# Ruby Hooks Handler for Dredd API Testing Framework
+Ruby Hooks Handler for Dredd API Testing Framework
+==================================================
 
 [![Build Status](https://travis-ci.org/apiaryio/dredd-hooks-ruby.svg?branch=master)](https://travis-ci.org/apiaryio/dredd-hooks-ruby)
 
-Test your api with [Dredd HTTP API testing framework](https://github.com/apiaryio/dredd) and write [hooks](http://dredd.readthedocs.org/en/latest/hooks/) in Ruby to glue together API Blueprint with your Ruby project.
+Test your API with the [Dredd HTTP API testing framework](https://github.com/apiaryio/dredd) and write [hooks](http://dredd.readthedocs.org/en/latest/hooks/) in Ruby!
 
-## Installation
+Installation
+------------
 
 Add the gem to your `Gemfile`:
 
@@ -15,11 +16,14 @@ Add the gem to your `Gemfile`:
 gem 'dredd_hooks', '0.1.0' # see semver.org
 ```
 
-## Usage
+Usage
+-----
 
-1. Create a hook file in `hooks.rb`:
+Create a hook file (name is arbitrary):
 
 ```ruby
+# ./hooks.rb
+
 include DreddHooks::Methods
 
 before "Machines > Machines collection > Get Machines" do |transaction|
@@ -27,30 +31,47 @@ before "Machines > Machines collection > Get Machines" do |transaction|
 end
 ```
 
-2. Run it with Dredd
+Run it with Dredd:
 
-```
-$ dredd apiary.apib localhost:3000 --language ruby --hookfiles ./hooks.rb
+```bash
+# note that the hooks file was named ./hooks.rb
+dredd apiary.apib localhost:3000 --language ruby --hookfiles ./hooks.rb
 ```
 
-## Documentation
+Documentation
+-------------
 
 ### API
 
-Module `DreddHooks::Methods` mixes in following methods `before`, `after`, `before_all`, `after_all`, `before_each`, `after_each`, `before_validation`, `before_each_validation`
+The `DreddHooks::Methods` module provides the following methods to be used with [transaction names][doc-names].
 
-`before`, `before_validation` `after` hooks are identified by [transaction name](http://dredd.readthedocs.org/en/latest/hooks/#getting-transaction-names).
+- `before`
+- `after`
+- `before_validation`
 
-Usage is very similar to [sync JS hooks API](http://dredd.readthedocs.org/en/latest/hooks/#sync-api)
+And these ones to be used without them:
 
-### Change log
+- `before_all`
+- `after_all`
+- `before_each`
+- `after_each`
+- `before_each_validation`
+
+See also the official [Hooks documentation][doc-hooks].
+
+  [doc-names]: http://dredd.readthedocs.org/en/latest/hooks/#getting-transaction-names
+  [doc-hooks]: https://dredd.readthedocs.org/en/latest/hooks
+
+Change log
+----------
 
 Releases are commented to provide a [brief change log][releases], details can be found in the [`CHANGELOG`][changelog] file.
 
   [releases]: https://github.com/gonzalo-bulnes/dredd-hooks-ruby/releases
   [changelog]: ./CHANGELOG.md
 
-## Development
+Development
+-----------
 
 ### Testing
 
@@ -59,15 +80,17 @@ Releases are commented to provide a [brief change log][releases], details can be
 rake
 ```
 
-## Contributing
+Contributing
+------------
 
 1. Fork it
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new Pull Request
+1. Create your feature branch (`git checkout -b my-new-feature`)
+1. Commit your changes (`git commit -am 'Add some feature'`)
+1. Push to the branch (`git push origin my-new-feature`)
+1. Create a new Pull Request
 
-## License
+License
+-------
 
 See [`LICENSE`][license].
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ gem 'dredd_hooks', '0.1.0' # see semver.org
 Usage
 -----
 
-Create a hook file (name is arbitrary):
+Create a hook file (the file name is arbitrary):
 
 ```ruby
 # ./hooks.rb
+
+require 'dredd_hooks/methods'
 
 include DreddHooks::Methods
 
@@ -43,7 +45,7 @@ Documentation
 
 ### API
 
-The `DreddHooks::Methods` module provides the following methods to be used with [transaction names][doc-names].
+The `DreddHooks::Methods` module provides the following methods to be used with [transaction names][doc-names]:
 
 - `before`
 - `after`


### PR DESCRIPTION
**As a** _dredd-hooks-ruby_ user
**In order to** know the project status
**And** be able to read the documentation in a terminal
**I want** its `README` to be formatted for source readability
**And** to display build, dependencies, code climate and inline doc badges

See also https://github.com/apiaryio/dredd-hooks-ruby/issues/5
