### PR TITLE
Refactor DRY Server::EventsHandler

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -12,7 +12,7 @@ In order to enable your new hook:
 1. Add the usage example to the [**Execution order** feature][feature]
 1. Run the entire test suite and watch the tests fail (start worrying if they don't!)
 1. Add the hook name to the corresponding list in the [definitions file][def]
-1. Add the corresponding Dredd **event** to the [events definition][events-handler]
+1. Add the corresponding Dredd **event** to the [events definition][events-handler] (be careful, the hooks order does matter!)
 1. Run the test suite and watch it pass : )
 
 Finally, bump the [_minor_][semver] version number, update the `README`, the `CHANGELOG` and do anything you need to do in order to release!

--- a/doc/README.md
+++ b/doc/README.md
@@ -12,13 +12,13 @@ In order to enable your new hook:
 1. Add the usage example to the [**Execution order** feature][feature]
 1. Run the entire test suite and watch the tests fail (start worrying if they don't!)
 1. Add the hook name to the corresponding list in the [definitions file][def]
-1. Add the corresponding Dredd **event** to the [server][server]
+1. Add the corresponding Dredd **event** to the [events definition][events-handler]
 1. Run the test suite and watch it pass : )
 
 Finally, bump the [_minor_][semver] version number, update the `README`, the `CHANGELOG` and do anything you need to do in order to release!
 
   [def]: ../lib/dredd_hooks/definitions.rb
-  [server]: ../lib/dredd_hooks/server.rb
+  [events-handler]: ../lib/dredd_hooks/server/events_handler.rb
 
   [runner-spec]: ../spec/lib/dredd_hooks/runner_spec.rb
   [methods-spec]: ../spec/lib/dredd_hooks/methods_spec.rb

--- a/lib/dredd_hooks/definitions.rb
+++ b/lib/dredd_hooks/definitions.rb
@@ -4,5 +4,27 @@ module DreddHooks
 
     HOOKS_ON_MULTIPLE_TRANSACTIONS = [:before_each, :before_each_validation,
                                       :after_each, :before_all, :after_all]
+
+    Server::EVENTS = {
+      beforeEach: [
+        :before_each,
+        :before,
+      ],
+      beforeEachValidation: [
+        :before_each_validation,
+        :before_validation,
+      ],
+      afterEach: [
+        :after,
+        :after_each,
+      ],
+      afterAll: [
+        :after_all,
+      ],
+      beforeAll: [
+        :before_all,
+      ],
+    }
+
 end
 

--- a/lib/dredd_hooks/errors.rb
+++ b/lib/dredd_hooks/errors.rb
@@ -1,0 +1,15 @@
+module DreddHooks
+
+  class UnknownHookError < RuntimeError
+
+    def initialize(hook_name)
+      @hook_name = hook_name
+    end
+
+    def to_s
+      "Unknown hook: #{@hook_name}"
+    end
+  end
+
+end
+

--- a/lib/dredd_hooks/server/events_handler.rb
+++ b/lib/dredd_hooks/server/events_handler.rb
@@ -1,39 +1,52 @@
+require 'dredd_hooks/errors'
 require 'dredd_hooks/runner'
 
 module DreddHooks
+
   class Server
+
+    EVENTS = {
+      beforeEach: [
+        :before_each,
+        :before,
+      ],
+      beforeEachValidation: [
+        :before_each_validation,
+        :before_validation,
+      ],
+      afterEach: [
+        :after,
+        :after_each,
+      ],
+      afterAll: [
+        :after_all,
+      ],
+      beforeAll: [
+        :before_all,
+      ],
+    }
+
     class EventsHandler
 
-      attr_reader :runner
-      private :runner
+      attr_reader :events, :runner
+      private :events, :runner
 
-      def initialize(runner=Runner.instance)
+      def initialize(events=EVENTS, runner=Runner.instance)
+        @events = events
         @runner = runner
       end
 
       def handle(event, transaction)
 
-        if event == "beforeEach"
-          transaction = runner.run_before_each_hooks_for_transaction(transaction)
-          transaction = runner.run_before_hooks_for_transaction(transaction)
-        end
-
-        if event == "beforeEachValidation"
-          transaction = runner.run_before_each_validation_hooks_for_transaction(transaction)
-          transaction = runner.run_before_validation_hooks_for_transaction(transaction)
-        end
-
-        if event == "afterEach"
-          transaction = runner.run_after_hooks_for_transaction(transaction)
-          transaction = runner.run_after_each_hooks_for_transaction(transaction)
-        end
-
-        if event == "beforeAll"
-          transaction = runner.run_before_all_hooks_for_transaction(transaction)
-        end
-
-        if event == "afterAll"
-          transaction = runner.run_after_all_hooks_for_transaction(transaction)
+        begin
+          events.fetch(event.to_sym).each do |hook_name|
+            begin
+              transaction = runner.send("run_#{hook_name}_hooks_for_transaction", transaction)
+            rescue NoMethodError
+              raise UnknownHookError.new(hook_name)
+            end
+          end
+        rescue KeyError => error
         end
 
         transaction

--- a/lib/dredd_hooks/server/events_handler.rb
+++ b/lib/dredd_hooks/server/events_handler.rb
@@ -1,31 +1,10 @@
+require 'dredd_hooks/definitions'
 require 'dredd_hooks/errors'
 require 'dredd_hooks/runner'
 
 module DreddHooks
 
   class Server
-
-    EVENTS = {
-      beforeEach: [
-        :before_each,
-        :before,
-      ],
-      beforeEachValidation: [
-        :before_each_validation,
-        :before_validation,
-      ],
-      afterEach: [
-        :after,
-        :after_each,
-      ],
-      afterAll: [
-        :after_all,
-      ],
-      beforeAll: [
-        :before_all,
-      ],
-    }
-
     class EventsHandler
 
       attr_reader :events, :runner

--- a/lib/dredd_hooks/server/events_handler.rb
+++ b/lib/dredd_hooks/server/events_handler.rb
@@ -7,8 +7,8 @@ module DreddHooks
       attr_reader :runner
       private :runner
 
-      def initialize
-        @runner = Runner.instance
+      def initialize(runner=Runner.instance)
+        @runner = runner
       end
 
       def handle(event, transaction)

--- a/spec/integration/definitions_consistency_spec.rb
+++ b/spec/integration/definitions_consistency_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+module DreddHooks
+  describe 'All the defined hooks', protected: true do
+
+    DEFINED_HOOKS = HOOKS_ON_SINGLE_TRANSACTIONS + HOOKS_ON_MULTIPLE_TRANSACTIONS
+
+    describe 'are runned on least one event' do
+
+      let(:hooks_in_use) { Server::EVENTS.map{ |_event, hooks| hooks }.flatten.uniq }
+
+      DEFINED_HOOKS.each do |hook_name|
+        it ":#{hook_name} is refered to by at least one event" do
+          expect(hooks_in_use).to include(hook_name)
+        end
+      end
+
+    end
+  end
+  
+  describe 'DreddHooks events definition', protected: true do
+
+    describe 'only refers to hooks that are already defined' do
+
+      let(:defined_hooks) { HOOKS_ON_SINGLE_TRANSACTIONS + HOOKS_ON_MULTIPLE_TRANSACTIONS }
+
+      Server::EVENTS.each do |_event, hook_names|
+        hook_names.each do |hook_name|
+          it ":#{hook_name} is defined" do
+            expect(defined_hooks).to include(hook_name)
+          end
+        end
+      end
+
+    end
+  end
+end
+

--- a/spec/lib/dredd_hooks/server/events_handler_spec.rb
+++ b/spec/lib/dredd_hooks/server/events_handler_spec.rb
@@ -3,18 +3,18 @@ require 'spec_helper'
 module DreddHooks
   describe Server::EventsHandler, private: true do
 
-   let(:events_handler) { described_class.new }
+    let(:events_handler) { described_class.new }
 
-   it { expect(events_handler).to respond_to :handle }
+    it { expect(events_handler).to respond_to :handle }
 
-   describe '#handle' do
+    describe '#handle' do
 
-     it 'returns a transaction' do
-       event = 'do_nothing'
+      it 'returns a transaction' do
+       event = 'doNothing'
        transaction = double()
        expect(events_handler.handle(event, transaction)).to eq transaction
-     end
-   end
+      end
+    end
   end
 end
 


### PR DESCRIPTION
**As a** developer
**In order to** make maintenance easier
**And** ensure adding support for new Dredd events is as simple as possible
**I want** the `DreddHooks::Server::EventsHandler` to be DRY

See https://github.com/apiaryio/dredd-hooks-ruby/issues/5
